### PR TITLE
implement sequences & add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /target
-test*
 
 # files from examples
 *-example.bin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsv-core"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 authors = ["Maxi Saparov <max.saparov@gmail.com>"]
 description = "RSV reading and writing with Serde support"

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -72,6 +72,20 @@ impl<'de> DeRecord<'de> {
 
         Ok(value)
     }
+
+    // Look at the first character in the input without consuming it.
+    fn peek_char(&mut self) -> Result<u8, Error> {
+        self.buf.iter().next().ok_or(Error(ErrorKind::Deserialize(
+            "Got None but expected char".to_owned()
+        ))).copied()
+    }
+
+    // Consume the first character in the input.
+    fn next_char(&mut self) -> Result<u8, Error> {
+        let ch = self.peek_char()?;
+        self.buf = &self.buf[1..];
+        Ok(ch)
+    }
 }
 
 impl<'a, 'de> Deserializer<'de> for &'a mut DeRecord<'de> {
@@ -261,7 +275,16 @@ impl<'a, 'de> Deserializer<'de> for &'a mut DeRecord<'de> {
     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de> {
-        todo!()
+        // Parse the row terminator.
+        if self.next_char()? == ROW_TERM_BYTE {
+            // Give the visitor access to each element of the sequence.
+            let value = visitor.visit_seq(self)?;
+            Ok(value)
+        } else {
+            Err(Error(ErrorKind::Deserialize(
+                "Unable to find ROW_TERM_BYTE in row".to_owned()
+            )))
+        }
     }
 
     fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
@@ -348,7 +371,7 @@ impl<'a, 'de> SeqAccess<'de> for DeRecord<'de> {
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
     where
         T: serde::de::DeserializeSeed<'de> {
-        if self.buf[0] == ROW_TERM_BYTE {
+        if self.buf.len() == 0 || self.buf[0] == ROW_TERM_BYTE {
             return Ok(None);
         }
 

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -72,20 +72,6 @@ impl<'de> DeRecord<'de> {
 
         Ok(value)
     }
-
-    // Look at the first character in the input without consuming it.
-    fn peek_char(&mut self) -> Result<u8, Error> {
-        self.buf.iter().next().ok_or(Error(ErrorKind::Deserialize(
-            "Got None but expected char".to_owned()
-        ))).copied()
-    }
-
-    // Consume the first character in the input.
-    fn next_char(&mut self) -> Result<u8, Error> {
-        let ch = self.peek_char()?;
-        self.buf = &self.buf[1..];
-        Ok(ch)
-    }
 }
 
 impl<'a, 'de> Deserializer<'de> for &'a mut DeRecord<'de> {
@@ -275,16 +261,7 @@ impl<'a, 'de> Deserializer<'de> for &'a mut DeRecord<'de> {
     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de> {
-        // Parse the row terminator.
-        if self.next_char()? == ROW_TERM_BYTE {
-            // Give the visitor access to each element of the sequence.
-            let value = visitor.visit_seq(self)?;
-            Ok(value)
-        } else {
-            Err(Error(ErrorKind::Deserialize(
-                "Unable to find ROW_TERM_BYTE in row".to_owned()
-            )))
-        }
+        visitor.visit_seq(self)
     }
 
     fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod error;
 pub mod writer;
 pub mod reader;
+pub mod utils;
 
 mod deserializer;
 mod serializer;
-mod utils;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,11 +1,15 @@
 use rsv_core::reader;
 use rsv_core::utils::{NULL_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE};
-use std::collections::HashSet;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+pub enum NoValue {
+    Empty {},
+}
 
 #[test]
 fn seq_deserialization() {
-    //type Rsv = Vec<HashSet<String>>;
-
     // empty buffer
     let buffer: Vec<u8> = vec![];
     let mut row_count = 0;
@@ -27,39 +31,63 @@ fn seq_deserialization() {
     assert!(row_count == 3);
 
     // 3 rows with empty strings
-    let buffer: Vec<u8> = vec![VALUE_TERM_BYTE, ROW_TERM_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE];
+    let buffer: Vec<u8> = vec![
+        VALUE_TERM_BYTE, ROW_TERM_BYTE,
+        VALUE_TERM_BYTE, ROW_TERM_BYTE,
+        VALUE_TERM_BYTE, ROW_TERM_BYTE
+    ];
     let mut row_count = 0;
     for result in reader::Reader::from_reader(&*buffer).deserialize::<Vec<String>>() {
         assert!(result.is_ok());
-        assert!(result.unwrap().len() == 0);
+        let row = result.unwrap();
+        assert!(row.len() == 1);
+        assert!(row[0] == "");
         row_count += 1;
     }
-    println!("{:#?}", row_count);
+    assert!(row_count == 3);
+
+    // 5 rows with non-empty strings
+    let buffer: Vec<u8> = vec![
+        b'a', VALUE_TERM_BYTE, ROW_TERM_BYTE,
+        b'a', b'b', b'c', VALUE_TERM_BYTE, ROW_TERM_BYTE,
+        b'x', VALUE_TERM_BYTE, ROW_TERM_BYTE,
+        b'y', VALUE_TERM_BYTE, ROW_TERM_BYTE,
+        b'z', VALUE_TERM_BYTE, ROW_TERM_BYTE
+    ];
+    let mut row_count = 0;
+    for result in reader::Reader::from_reader(&*buffer).deserialize::<Vec<String>>() {
+        assert!(result.is_ok());
+        assert!(result.unwrap().len() > 0);
+        row_count += 1;
+    }
+    assert!(row_count == 5);
+
+    // 3 rows with multiple strings
+    let buffer: Vec<u8> = vec![
+        b'a', VALUE_TERM_BYTE, b'a', b'b', b'c', VALUE_TERM_BYTE, b'x', VALUE_TERM_BYTE, ROW_TERM_BYTE,
+        ROW_TERM_BYTE,
+        b'y', VALUE_TERM_BYTE, b'x', b'z', VALUE_TERM_BYTE, ROW_TERM_BYTE
+    ];
+    let mut row_count = 0;
+    for result in reader::Reader::from_reader(&*buffer).deserialize::<Vec<String>>() {
+        assert!(result.is_ok());
+        let value = result.unwrap();
+        if row_count == 1 {
+            assert!(value.len() == 0);
+        } else {
+            assert!(value.len() > 1);
+        }
+        row_count += 1;
+    }
     assert!(row_count == 3);
 
     // 2 rows with null values
-    let buffer: Vec<u8> = vec![NULL_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE, NULL_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE];
+    /* let buffer: Vec<u8> = vec![NULL_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE, NULL_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE];
     let mut row_count = 0;
-    for result in reader::Reader::from_reader(&*buffer).deserialize::<Vec<String>>() {
-        println!("{:#?}", result);
+    for result in reader::Reader::from_reader(&*buffer).deserialize::<Vec<NoValue>>() {
         assert!(result.is_ok());
         assert!(result.unwrap().len() == 1);
         row_count += 1;
     }
-    println!("{:#?}", row_count);
-    assert!(row_count == 2);
-
-    // 5 rows with non-empty strings
-    let buffer: Vec<u8> = vec![b'a', VALUE_TERM_BYTE, ROW_TERM_BYTE, b'a', b'b', b'c', VALUE_TERM_BYTE, ROW_TERM_BYTE, b'x', VALUE_TERM_BYTE, ROW_TERM_BYTE, b'y', VALUE_TERM_BYTE, ROW_TERM_BYTE, b'z', VALUE_TERM_BYTE, ROW_TERM_BYTE];
-    let mut row_count = 0;
-    for result in reader::Reader::from_reader(&*buffer).deserialize::<Vec<String>>() {
-        println!("{:#?}", result);
-        assert!(result.is_ok());
-        let value = result.unwrap();
-        assert!(value.len() > 0);
-        println!("{:#?}", value);
-        row_count += 1;
-    }
-    println!("{:#?}", row_count);
-    assert!(row_count == 5);
+    assert!(row_count == 2); */
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,0 +1,65 @@
+use rsv_core::reader;
+use rsv_core::utils::{NULL_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE};
+use std::collections::HashSet;
+
+#[test]
+fn seq_deserialization() {
+    //type Rsv = Vec<HashSet<String>>;
+
+    // empty buffer
+    let buffer: Vec<u8> = vec![];
+    let mut row_count = 0;
+    for result in reader::Reader::from_reader(&*buffer).deserialize::<Vec<String>>() {
+        assert!(result.is_ok());
+        assert!(result.unwrap().len() == 0);
+        row_count += 1;
+    }
+    assert!(row_count == 0);
+
+    // 3 empty rows
+    let buffer: Vec<u8> = vec![ROW_TERM_BYTE, ROW_TERM_BYTE, ROW_TERM_BYTE];
+    let mut row_count = 0;
+    for result in reader::Reader::from_reader(&*buffer).deserialize::<Vec<String>>() {
+        assert!(result.is_ok());
+        assert!(result.unwrap().len() == 0);
+        row_count += 1;
+    }
+    assert!(row_count == 3);
+
+    // 3 rows with empty strings
+    let buffer: Vec<u8> = vec![VALUE_TERM_BYTE, ROW_TERM_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE];
+    let mut row_count = 0;
+    for result in reader::Reader::from_reader(&*buffer).deserialize::<Vec<String>>() {
+        assert!(result.is_ok());
+        assert!(result.unwrap().len() == 0);
+        row_count += 1;
+    }
+    println!("{:#?}", row_count);
+    assert!(row_count == 3);
+
+    // 2 rows with null values
+    let buffer: Vec<u8> = vec![NULL_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE, NULL_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE];
+    let mut row_count = 0;
+    for result in reader::Reader::from_reader(&*buffer).deserialize::<Vec<String>>() {
+        println!("{:#?}", result);
+        assert!(result.is_ok());
+        assert!(result.unwrap().len() == 1);
+        row_count += 1;
+    }
+    println!("{:#?}", row_count);
+    assert!(row_count == 2);
+
+    // 5 rows with non-empty strings
+    let buffer: Vec<u8> = vec![b'a', VALUE_TERM_BYTE, ROW_TERM_BYTE, b'a', b'b', b'c', VALUE_TERM_BYTE, ROW_TERM_BYTE, b'x', VALUE_TERM_BYTE, ROW_TERM_BYTE, b'y', VALUE_TERM_BYTE, ROW_TERM_BYTE, b'z', VALUE_TERM_BYTE, ROW_TERM_BYTE];
+    let mut row_count = 0;
+    for result in reader::Reader::from_reader(&*buffer).deserialize::<Vec<String>>() {
+        println!("{:#?}", result);
+        assert!(result.is_ok());
+        let value = result.unwrap();
+        assert!(value.len() > 0);
+        println!("{:#?}", value);
+        row_count += 1;
+    }
+    println!("{:#?}", row_count);
+    assert!(row_count == 5);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -82,12 +82,14 @@ fn seq_deserialization() {
     assert!(row_count == 3);
 
     // 2 rows with null values
-    /* let buffer: Vec<u8> = vec![NULL_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE, NULL_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE];
+    let buffer: Vec<u8> = vec![NULL_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE, NULL_BYTE, VALUE_TERM_BYTE, ROW_TERM_BYTE];
     let mut row_count = 0;
-    for result in reader::Reader::from_reader(&*buffer).deserialize::<Vec<NoValue>>() {
+    for result in reader::Reader::from_reader(&*buffer).deserialize::<Vec<Option<String>>>() {
         assert!(result.is_ok());
-        assert!(result.unwrap().len() == 1);
+        let row = result.unwrap();
+        assert!(row.len() == 1);
+        assert!(row[0].is_none());
         row_count += 1;
     }
-    assert!(row_count == 2); */
+    assert!(row_count == 2);
 }


### PR DESCRIPTION
This change adds support for sequences and tests using this to deserialize samples into vectors containing strings.

Changes:
- implement sequences
- allow elements/rows to be empty
- add some integration tests
- fixes #1 (sequences)

To Discuss:
- [x] Are the tests in the external directory in an appropriate spot or should they be moved into the `src` directory? Or should the tests live inside the source files?
- [x] The .gitignore currently ignores `test*`. Should this be removed?
- [x] Didn't get the Null values deserialized, yet. In the currently commented test I tried using an enum with an empty value, which would call sequence_any. A vector of None doesn't make sense either. How could I test if None is in the deserialized sequence?